### PR TITLE
Remove CNAME.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.veres.one


### PR DESCRIPTION
When an attempt is made to access https://veres-one.github.io/docs.veres.one github is doing a redirect to http://docs.veres.one.  I believe by eliminating this file, the github redirect will no longer occur.  We must address the redirect before introducing the proxy otherwise a circular redirect will occur (I believe).